### PR TITLE
Disable sni (environment variable)

### DIFF
--- a/src/server/pg.rs
+++ b/src/server/pg.rs
@@ -67,16 +67,27 @@ async fn connect(
             .map_err(|e| format!("Could not read certificate:\n{}", e) )?;
         let cert = Certificate::from_pem(&cert_content)
             .map_err(|e| format!("{}", e) )?;
-        let connector = TlsConnector::builder()
-            .add_root_certificate(cert)
-            .use_sni(true)
-            .disable_built_in_roots(false)
-            .min_protocol_version(Some(min_version))
-            .build()
-            .map_err(|e| format!("Error establishing TLS connector:\n{}", e) )?;
+        let connector = if uri.info.hostname_verification == false {
+        		TlsConnector::builder()
+            	.add_root_certificate(cert)
+            	.use_sni(true)
+            	.disable_built_in_roots(false)
+            	.min_protocol_version(Some(min_version))
+            	.danger_accept_invalid_hostnames(true)
+            	.build()
+            	.map_err(|e| format!("Error establishing TLS connector:\n{}", e) )?
+            } else {
+        		TlsConnector::builder()
+            	.add_root_certificate(cert)
+            	.use_sni(true)
+            	.disable_built_in_roots(false)
+            	.min_protocol_version(Some(min_version))
+            	.build()
+            	.map_err(|e| format!("Error establishing TLS connector:\n{}", e) )?
+            };
         
         let connector = MakeTlsConnector::new(connector);
-        if !uri.uri.ends_with("sslmode=require") {
+        if !uri.uri.ends_with("sslmode=require") && !uri.uri.ends_with("sslmode=verify-ca") {
             return Err(format!("Tried to connect without TLS mode 'require'"));
         }
         

--- a/src/ui/overview.rs
+++ b/src/ui/overview.rs
@@ -368,6 +368,7 @@ pub struct ConnectionBox {
     pub user : PackedImageEntry,
     pub db : PackedImageEntry,
     pub password : PackedImagePasswordEntry,
+    pub hostname_verification : ToggleButton,
     pub switch : Switch,
     bx : Box
 }
@@ -381,6 +382,8 @@ impl ConnectionBox {
         let user = PackedImageEntry::build("avatar-default-symbolic", "User");
         let password = PackedImagePasswordEntry::build("dialog-password-symbolic", "Password");
         let switch = Switch::new();
+        let hostname_verification = ToggleButton::with_label("Disable Hostname Verification");
+        hostname_verification.set_vexpand(false);
         switch.set_valign(Align::Center);
         switch.set_vexpand(false);
         cred_bx.append(&user.bx);
@@ -392,6 +395,7 @@ impl ConnectionBox {
         bx.append(&host.bx);
         bx.append(&db.bx);
         bx.append(&cred_bx);
+        bx.append(&hostname_verification);
         bx.set_margin_bottom(36);
 
         host.entry.set_hexpand(true);
@@ -405,6 +409,7 @@ impl ConnectionBox {
             db,
             password,
             bx,
+            hostname_verification,
             switch
         };
         conn_bx.set_sensitive(false);
@@ -449,6 +454,7 @@ impl ConnectionBox {
         self.db.entry.set_sensitive(sensitive);
         self.user.entry.set_sensitive(sensitive);
         self.password.entry.set_sensitive(sensitive);
+        self.hostname_verification.set_sensitive(sensitive);
         self.switch.set_sensitive(sensitive);
     }
 

--- a/src/ui/overview.rs
+++ b/src/ui/overview.rs
@@ -368,7 +368,6 @@ pub struct ConnectionBox {
     pub user : PackedImageEntry,
     pub db : PackedImageEntry,
     pub password : PackedImagePasswordEntry,
-    pub hostname_verification : ToggleButton,
     pub switch : Switch,
     bx : Box
 }
@@ -382,8 +381,6 @@ impl ConnectionBox {
         let user = PackedImageEntry::build("avatar-default-symbolic", "User");
         let password = PackedImagePasswordEntry::build("dialog-password-symbolic", "Password");
         let switch = Switch::new();
-        let hostname_verification = ToggleButton::with_label("Disable Hostname Verification");
-        hostname_verification.set_vexpand(false);
         switch.set_valign(Align::Center);
         switch.set_vexpand(false);
         cred_bx.append(&user.bx);
@@ -395,7 +392,6 @@ impl ConnectionBox {
         bx.append(&host.bx);
         bx.append(&db.bx);
         bx.append(&cred_bx);
-        bx.append(&hostname_verification);
         bx.set_margin_bottom(36);
 
         host.entry.set_hexpand(true);
@@ -409,7 +405,6 @@ impl ConnectionBox {
             db,
             password,
             bx,
-            hostname_verification,
             switch
         };
         conn_bx.set_sensitive(false);
@@ -454,7 +449,6 @@ impl ConnectionBox {
         self.db.entry.set_sensitive(sensitive);
         self.user.entry.set_sensitive(sensitive);
         self.password.entry.set_sensitive(sensitive);
-        self.hostname_verification.set_sensitive(sensitive);
         self.switch.set_sensitive(sensitive);
     }
 

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -598,7 +598,7 @@ impl SecurityBox {
         cert_entry.set_placeholder_text(Some("Root certificate path (.crt or .pem file)"));
         cert_entry.set_hexpand(true);
         cert_entry.set_halign(Align::Fill);
-        
+
         let add_bx_top = Box::new(Orientation::Horizontal, 0);
         let add_bx_middle = Box::new(Orientation::Horizontal, 0);
         let add_bx_bottom = Box::new(Orientation::Horizontal, 0);
@@ -612,7 +612,7 @@ impl SecurityBox {
         super::set_margins(&add_bx, 12, 12);
         add_btn.set_halign(Align::End);
         add_btn.set_hexpand(false);
-        
+
         let version_combo = ComboBoxText::new();
         
         for (id, mode) in [("0", TLS_V10), ("1", TLS_V11), ("2", TLS_V12)] {


### PR DESCRIPTION
This adds an environment variable (QUERIES_DISABLE_SNI) that, when set to true, disables hostname verification during TLS negotiation to postgres servers. This keeps the UI engine agnostic, and allows users to connect in situations where the hostname they are whitelisted on is not the hostname of the server (common in AWS). Since it is an environment variable, it should be a sufficiently high barrier to usage so that users not familiar with the setting and it's implications won't set it by accident.

Closes #1.