### PR TITLE
appdata: Fix appdata papercuts

### DIFF
--- a/data/io.github.limads.Queries.appdata.xml
+++ b/data/io.github.limads.Queries.appdata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<component type="desktop">
+<component type="desktop-application">
 
-    <id>io.github.limads.Queries.desktop</id>
+    <id>io.github.limads.Queries</id>
     
     <name>Queries</name>
     
@@ -10,7 +10,7 @@
     
     <project_license>GPL-3.0-or-later</project_license>
     
-    <summary>A workbench to interact with relational databases.</summary>
+    <summary>A workbench to interact with relational databases</summary>
     
     <description>
         <p>Queries is a workbench to interact with relational databases, with initial support for Postgres.</p>
@@ -25,31 +25,33 @@
         </ul>
     </description>
     
-    <categories>
-        <category>Office</category>
-        <category>Development</category>
-    </categories>
-    
-    <keywords>
-        <keyword translate="no">SQL</keyword>
-        <keyword translate="no">Database</keyword>
-        <keyword translate="no">Postgres</keyword>
-    </keywords>
-  
+    <launchable type="desktop-id">io.github.limads.Queries.desktop</launchable>
     <developer_name>Diego Lima</developer_name>
+    <developer id="io.github.limads">
+        <name>Diego Lima</name>
+    </developer>
     
     <url type="homepage">https://github.com/limads/queries</url>
     <url type="bugtracker">https://github.com/limads/queries/issues</url>
+    <url type="vcs-browser">https://github.com/limads/queries</url>
     <url type="donation">https://github.com/sponsors/limads</url>
     <url type="help">https://github.com/limads/queries/wiki</url>
     
     <screenshots>
-      <screenshot>
-          <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen1.png</image>
-          <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen2.png</image>
-          <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen3.png</image>
-          <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen4.png</image>
-          <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen5.png</image>
+        <screenshot type="default">
+            <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen1.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen2.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen3.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen4.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen5.png</image>
         </screenshot>
     </screenshots>
     
@@ -85,5 +87,9 @@
     </releases>
   
     <content_rating type="oars-1.1" />
+
+    <provides>
+        <id>io.github.limads.Queries.desktop</id>
+    </provides>
   
 </component>


### PR DESCRIPTION
- Use desktop-application as component type
- Remove the desktop extension from Id part
- Add the old id to provides tag
- Remove categories and keywords from appdata which are provided via the desktop file
- Add vcs-browser URL to show the source code
- Fix the screenshot tags
- Add developer block with io.hithub.limads ID

More information: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/